### PR TITLE
Implement Headless Google OAuth. Fixes: #14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,7 +157,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # macOs
 **/.DS_Store

--- a/comrade/comrade/settings.py
+++ b/comrade/comrade/settings.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     "comrade_core",
     "allauth",
     "allauth.account",
+    "allauth.headless",
     "allauth.socialaccount",
     "allauth.socialaccount.providers.google",
     "rest_framework",

--- a/comrade/comrade/settings.py
+++ b/comrade/comrade/settings.py
@@ -113,6 +113,8 @@ AUTHENTICATION_BACKENDS = [
     "allauth.account.auth_backends.AuthenticationBackend",
 ]
 
+HEADLESS_TOKEN_STRATEGY = "comrade.token_strategy.ComradeTokenStrategy"
+
 CSRF_TRUSTED_ORIGINS = ["https://knowing-massive-macaw.ngrok-free.app"]
 
 LOGIN_URL = "/accounts/login/"

--- a/comrade/comrade/token_strategy.py
+++ b/comrade/comrade/token_strategy.py
@@ -1,0 +1,12 @@
+import typing
+
+from allauth.headless.tokens.sessions import SessionTokenStrategy
+from django.http import HttpRequest
+from rest_framework.authtoken.models import Token
+
+
+class ComradeTokenStrategy(SessionTokenStrategy):
+
+    def create_access_token(self, request: HttpRequest) -> typing.Optional[typing.Dict[str, typing.Any]]:
+        token, _ = Token.objects.get_or_create(user=request.user)
+        return token.key

--- a/comrade/comrade/urls.py
+++ b/comrade/comrade/urls.py
@@ -24,4 +24,5 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api-auth/", include("rest_framework.urls")),
     path("accounts/", include("allauth.urls")),
+    path("_allauth/", include("allauth.headless.urls")),
 ]

--- a/comrade/comrade_core/templates/google.html
+++ b/comrade/comrade_core/templates/google.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+{% if error %}
+    {{ error }} <br>
+{% endif %}
+
+<button onclick="oauthSignIn()">Sign in with Google</button>
+
+</body>
+<script>
+    /*
+ * Create form to request access token from Google's OAuth 2.0 server.
+ */
+    function oauthSignIn() {
+        // Google's OAuth 2.0 endpoint for requesting an access token
+        var oauth2Endpoint = 'https://accounts.google.com/o/oauth2/v2/auth';
+
+        // Create <form> element to submit parameters to OAuth 2.0 endpoint.
+        var form = document.createElement('form');
+        form.setAttribute('method', 'GET'); // Send as a GET request.
+        form.setAttribute('action', oauth2Endpoint);
+
+        // Parameters to pass to OAuth 2.0 endpoint.
+        var params = {
+            'client_id': '{{ client_id }}',
+            'redirect_uri': 'http://localhost:8000/google',
+            'response_type': 'id_token token',
+            'scope': 'https://www.googleapis.com/auth/drive.metadata.readonly https://www.googleapis.com/auth/calendar.readonly',
+            'include_granted_scopes': 'true',
+            'state': 'pass-through value',
+            'nonce': generateRandomString(10)
+        };
+
+        // Add form parameters as hidden input values.
+        for (var p in params) {
+            var input = document.createElement('input');
+            input.setAttribute('type', 'hidden');
+            input.setAttribute('name', p);
+            input.setAttribute('value', params[p]);
+            form.appendChild(input);
+        }
+
+        // Add form to page and submit it to open the OAuth 2.0 endpoint.
+        document.body.appendChild(form);
+        form.submit();
+    }
+
+    function generateRandomString(length) {
+        return Array.from({length}, () => 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'.charAt(Math.floor(Math.random() * 64))).join('');
+    }
+</script>
+</html>

--- a/comrade/comrade_core/urls.py
+++ b/comrade/comrade_core/urls.py
@@ -6,6 +6,7 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('google/', views.google, name='google'),
     path('user/', views.UserDetailView.as_view(), name='user_detail'),
     path('user/token/', views.login_view, name='login'),
     path('map/', views.map, name='map'),

--- a/comrade/comrade_core/views.py
+++ b/comrade/comrade_core/views.py
@@ -5,6 +5,11 @@ import random
 from typing import AsyncGenerator, Callable
 
 import redis
+from allauth.socialaccount.adapter import (
+    get_adapter as get_socialaccount_adapter,
+)
+from allauth.socialaccount.models import SocialApp
+
 from comrade_core.models import Task
 from comrade_core.serializers import GroupSerializer, TaskSerializer, UserSerializer
 from django.conf import settings
@@ -24,6 +29,20 @@ from rest_framework.views import APIView
 
 def index(request):
     return render(request, "index.html")
+
+def google(request):
+    try:
+        provider = get_socialaccount_adapter().get_provider(
+            request, "google"
+        )
+        context = {
+            "client_id": provider.app.client_id,
+        }
+    except SocialApp.DoesNotExist:
+        context = {
+            "error": "Google social app not found. Check Sites in configuration.",
+        }
+    return render(request, "google.html", context=context)
 
 def map(request):
     return render(request, "map.html")


### PR DESCRIPTION
I got bored so I tried to implement the Google Login #14 

Steps to set-up/test
* Create a new app in [Google developer console](https://console.developers.google.com/project)
  * Set redirect to `http://localhost:8000/google`
  * Grab Client ID and Secret Key
* Create a new Social Application in Django Admin panel (http://localhost:8000/admin/socialaccount/socialapp/add/)
  * Fill the Client ID & Secret Key
  * **Select a Site at the bottom part of the form**
  * You should see a Google Provider with `provider_token` flow http://localhost:8000/_allauth/app/v1/config
* Go to http://localhost:8000/google/ and click the button to initialize the OAuth process
* Once completed, you should be back on localhost with an `id_token` in the URL

Send a POST request to get the API's `access_token`

```js
// http://localhost:8000/_allauth/app/v1/auth/provider/token
{
    "provider": "google",
    "process": "login",
    "token": {
        "client_id": "...",
        "id_token": "..."
    }
}
```

You should get a response
```js
{
    // snip
    "meta": {
        "is_authenticated": true,
        "session_token": "...",
        "access_token": "<access_token>"
    }
}
```

To verify `access_token`, send a request to `http://localhost:8000/user` with header `Authorization: Token <access_token>`